### PR TITLE
fix: .env update in stelace-server not applied

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Env variables are needed to run tests with API server running
-# This file was copied from stelace-server repo (January 2020)
+# This file was copied from stelace-server repo (June 2020)
 
 # development, test or production
 NODE_ENV=development
@@ -36,7 +36,8 @@ INSTALLED_PLUGINS=
 # Set host to 'redis' and change port if needed when using dockerized API
 REDIS_PORT=6379
 REDIS_HOST=127.0.0.1
-# REDIS_HOST=redis # when using Stelace API server docker container
+# When using Stelace API server docker container:
+# REDIS_HOST=redis
 REDIS_DBNUM=0
 REDIS_PASSWORD=
 REDIS_TLS=false
@@ -45,9 +46,10 @@ REDIS_TLS=false
 # Otherwise docker-compose file maps from 5432 PostgreSQL default port number in container
 # to 6543 host port in order to avoid conflicts since PostgreSQL often ships with OS.
 POSTGRES_HOST=127.0.0.1
-# POSTGRES_HOST=postgresql # when using Stelace API server docker container
 POSTGRES_PORT=6543
-# POSTGRES_PORT=5432 # when using Stelace API server docker container
+# When using Stelace API server docker container:
+# POSTGRES_HOST=postgresql
+# POSTGRES_PORT=5432
 POSTGRES_DB=stelace-core
 POSTGRES_USER=user
 POSTGRES_PASSWORD=password
@@ -55,11 +57,12 @@ POSTGRES_ADMIN_USER=postgres
 
 # Set host to 'elasticsearch' when using dockerized API
 ELASTIC_SEARCH_HOST=127.0.0.1
-# ELASTIC_SEARCH_HOST=elasticsearch # when using Stelace API server docker container
+# When using Stelace API server docker container:
+# ELASTIC_SEARCH_HOST=elasticsearch
 ELASTIC_SEARCH_PROTOCOL=http
 ELASTIC_SEARCH_PORT=9200
 ELASTIC_SEARCH_USER=elastic
-ELASTIC_SEARCH_PASSWORD=changeme
+ELASTIC_SEARCH_PASSWORD=elastic_password
 
 # Load database settings from redis to support multiple databases
 REMOTE_STORE=true


### PR DESCRIPTION
`ELASTIC_SEARCH_PASSWORD` was changed in
https://github.com/stelace/stelace/commit/80e5a92ad9aa1e6a9e238c1aade50d06c2dc8d1b